### PR TITLE
Clean up cross-platform to native conversions.

### DIFF
--- a/src/GoogleUserMessagingPlatform/ConsentDebugSettings.android.cs
+++ b/src/GoogleUserMessagingPlatform/ConsentDebugSettings.android.cs
@@ -7,7 +7,7 @@ namespace Plugin.GoogleUserMessagingPlatform
         public Xamarin.Google.UserMesssagingPlatform.ConsentDebugSettings ToPlatform()
         {
             var builder = new Xamarin.Google.UserMesssagingPlatform.ConsentDebugSettings.Builder(Platform.CurrentActivity)
-                .SetDebugGeography((int)Geography);
+                .SetDebugGeography(Geography.ToPlatform());
 
             foreach (var id in AndroidTestDeviceIds)
             {

--- a/src/GoogleUserMessagingPlatform/Extensions.android.cs
+++ b/src/GoogleUserMessagingPlatform/Extensions.android.cs
@@ -1,25 +1,46 @@
-﻿namespace Plugin.GoogleUserMessagingPlatform
+﻿using Xamarin.Google.UserMesssagingPlatform;
+
+namespace Plugin.GoogleUserMessagingPlatform
 {
     public static class Extensions
     {
         public static ConsentStatus ToConsentStatus(this int status)
         {
-            return (ConsentStatus)status;
+            return status switch
+            {
+                ConsentInformationConsentStatus.Unknown => ConsentStatus.Unknown,
+                ConsentInformationConsentStatus.Required => ConsentStatus.Required,
+                ConsentInformationConsentStatus.NotRequired => ConsentStatus.NotRequired,
+                ConsentInformationConsentStatus.Obtained => ConsentStatus.Obtained,
+                _ => ConsentStatus.Unknown,
+            };
         }
 
         public static ConsentType ToConsentType(this int type)
         {
-            return (ConsentType)type;
-        }
-
-        public static FormStatus ToFormStatus(this int status)
-        {
-            return (FormStatus)status;
+            return type switch
+            {
+                ConsentInformationConsentType.Unknown => ConsentType.Unknown,
+                ConsentInformationConsentType.Personalized => ConsentType.Unknown,
+                ConsentInformationConsentType.NonPersonalized => ConsentType.Unknown,
+                _ => ConsentType.Unknown,
+            };
         }
 
         public static DebugGeography ToDebugGeography(this int geography)
         {
             return (DebugGeography)geography;
+        }
+
+        public static int ToPlatform(this DebugGeography geography)
+        {
+            return geography switch
+            {
+                DebugGeography.Disabled => Xamarin.Google.UserMesssagingPlatform.ConsentDebugSettings.DebugGeography.DebugGeographyDisabled,
+                DebugGeography.Eea => Xamarin.Google.UserMesssagingPlatform.ConsentDebugSettings.DebugGeography.DebugGeographyEea,
+                DebugGeography.NotEea => Xamarin.Google.UserMesssagingPlatform.ConsentDebugSettings.DebugGeography.DebugGeographyNotEea,
+                _ => Xamarin.Google.UserMesssagingPlatform.ConsentDebugSettings.DebugGeography.DebugGeographyDisabled,
+            };
         }
     }
 }

--- a/src/GoogleUserMessagingPlatform/Extensions.ios.cs
+++ b/src/GoogleUserMessagingPlatform/Extensions.ios.cs
@@ -4,27 +4,58 @@
     {
         public static ConsentStatus ToConsentStatus(this Google.MobileAds.Consent.ConsentStatus status)
         {
-            return (ConsentStatus)(int)status;
+            return status switch
+            {
+                Google.MobileAds.Consent.ConsentStatus.Unknown => ConsentStatus.Unknown,
+                Google.MobileAds.Consent.ConsentStatus.Required => ConsentStatus.Required,
+                Google.MobileAds.Consent.ConsentStatus.NotRequired => ConsentStatus.NotRequired,
+                Google.MobileAds.Consent.ConsentStatus.Obtained => ConsentStatus.Obtained,
+                _ => ConsentStatus.Unknown,
+            };
         }
 
         public static ConsentType ToConsentType(this Google.MobileAds.Consent.ConsentType type)
         {
-            return (ConsentType)(int)type;
+            return type switch
+            {
+                Google.MobileAds.Consent.ConsentType.Unknown => ConsentType.Unknown,
+                Google.MobileAds.Consent.ConsentType.Personalized => ConsentType.Unknown,
+                Google.MobileAds.Consent.ConsentType.NonPersonalized => ConsentType.Unknown,
+                _ => ConsentType.Unknown,
+            };
         }
 
         public static FormStatus ToFormStatus(this Google.MobileAds.Consent.FormStatus status)
         {
-            return (FormStatus)(int)status;
+            return status switch
+            {
+                Google.MobileAds.Consent.FormStatus.Unknown => FormStatus.Unknown,
+                Google.MobileAds.Consent.FormStatus.Available => FormStatus.Available,
+                Google.MobileAds.Consent.FormStatus.Unavailable => FormStatus.Unavailable,
+                _ => FormStatus.Unknown,
+            };
         }
 
         public static DebugGeography ToDebugGeography(this Google.MobileAds.Consent.DebugGeography geography)
         {
-            return (DebugGeography)(int)geography;
+            return geography switch
+            {
+                Google.MobileAds.Consent.DebugGeography.Disabled => DebugGeography.Disabled,
+                Google.MobileAds.Consent.DebugGeography.Eea => DebugGeography.Eea,
+                Google.MobileAds.Consent.DebugGeography.NotEea => DebugGeography.NotEea,
+                _ => DebugGeography.Disabled,
+            };
         }
 
         public static Google.MobileAds.Consent.DebugGeography ToPlatform(this DebugGeography geography)
         {
-            return (Google.MobileAds.Consent.DebugGeography)(int)geography;
+            return geography switch
+            {
+                DebugGeography.Disabled => Google.MobileAds.Consent.DebugGeography.Disabled,
+                DebugGeography.Eea => Google.MobileAds.Consent.DebugGeography.Eea,
+                DebugGeography.NotEea => Google.MobileAds.Consent.DebugGeography.NotEea,
+                _ => Google.MobileAds.Consent.DebugGeography.Disabled,
+            };
         }
     }
 }

--- a/src/GoogleUserMessagingPlatform/GoogleUserMessagingPlatform.csproj
+++ b/src/GoogleUserMessagingPlatform/GoogleUserMessagingPlatform.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>Plugin.GoogleUserMessagingPlatform</PackageId>
-    <PackageVersion>0.0.7-alpha</PackageVersion>
+    <PackageVersion>0.0.8-alpha</PackageVersion>
     <Authors>Oliver Brown</Authors>
     <PackageProjectUrl>https://github.com/GalaxiaGuy/GoogleUserMessagingPlatform</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GalaxiaGuy/GoogleUserMessagingPlatform</RepositoryUrl>

--- a/src/GoogleUserMessagingPlatform/GoogleUserMessagingPlatform.csproj
+++ b/src/GoogleUserMessagingPlatform/GoogleUserMessagingPlatform.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;Xamarin.iOS10;MonoAndroid9.0;</TargetFrameworks>
@@ -6,12 +6,8 @@
     <RootNamespace>Plugin.GoogleUserMessagingPlatform</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>Plugin.GoogleUserMessagingPlatform</PackageId>
-    <PackageVersion>0.0.8-alpha</PackageVersion>
     <Authors>Oliver Brown</Authors>
     <PackageProjectUrl>https://github.com/GalaxiaGuy/GoogleUserMessagingPlatform</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GalaxiaGuy/GoogleUserMessagingPlatform</RepositoryUrl>
@@ -23,8 +19,18 @@ https://developers.google.com/admob/ump/ios/quick-start</Description>
   </PropertyGroup>
     
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeSymbols>true</IncludeSymbols>
     <DebugSymbols>true</DebugSymbols>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <ItemGroup>    
     <Compile Include="**\*.shared.cs" />
     <Compile Include="**\*.shared.*.cs" />


### PR DESCRIPTION
The Android and iOS implementations of UMP use different values for consent status. This fixes all the conversions between platform-specific and cross-platform values to be explicit.

Possibly fixes #8.